### PR TITLE
Change trigger to only update timestamp when not manually changed

### DIFF
--- a/postgres.ts
+++ b/postgres.ts
@@ -67,10 +67,11 @@ export class PostgresMigrate<GenerateOptions = unknown>
       );
     `;
     await transaction.queryArray`
-      CREATE FUNCTION trigger_migration_timestamp()
-      RETURNS TRIGGER AS $$
+      CREATE FUNCTION trigger_migration_timestamp() RETURNS TRIGGER AS $$
         BEGIN
-          NEW.updated_at = now();
+          IF NEW.updated_at = OLD.updated_at THEN
+            NEW.updated_at = now();
+          END IF;
           RETURN NEW;
         END;
       $$ LANGUAGE plpgsql;


### PR DESCRIPTION
Before there was no way to set an updated_at timestamp because the trigger would overwrite it with the current date. If you've initialized migrate before this change, you can fix this issue by either manually running the following query or adding a migration for it. If you don't intend on ever manually overwriting this value, there is no need to replace the trigger with the new one.

```sql
CREATE OR REPLACE FUNCTION trigger_migration_timestamp() RETURNS TRIGGER AS $$
  BEGIN
    IF NEW.updated_at = OLD.updated_at THEN
      NEW.updated_at = now();
    END IF;
    RETURN NEW;
  END;
$$ LANGUAGE plpgsql;
```