### PR TITLE
Upgrade deno and dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Migrate
 
-[![version](https://img.shields.io/badge/release-0.2.4-success)](https://deno.land/x/migrate@0.2.4)
+[![version](https://img.shields.io/badge/release-0.2.5-success)](https://deno.land/x/migrate@0.2.4)
 [![CI](https://github.com/udibo/migrate/workflows/CI/badge.svg)](https://github.com/udibo/migrate/actions?query=workflow%3ACI)
 [![codecov](https://codecov.io/gh/udibo/migrate/branch/main/graph/badge.svg?token=8Q7TSUFWUY)](https://codecov.io/gh/udibo/migrate)
 [![license](https://img.shields.io/github/license/udibo/migrate)](https://github.com/udibo/migrate/blob/master/LICENSE)
@@ -21,9 +21,9 @@ Currently migrate is only implemented for Postgres. The main entrypoint is
 
 ```ts
 // Import from Deno's third party module registry
-import { PostgresMigrate } from "https://deno.land/x/migrate@0.2.4/postgres.ts";
+import { PostgresMigrate } from "https://deno.land/x/migrate@0.2.5/postgres.ts";
 // Import from GitHub
-import { PostgresMigrate } "https://raw.githubusercontent.com/udibo/migrate/0.2.4/postgres.ts";
+import { PostgresMigrate } "https://raw.githubusercontent.com/udibo/migrate/0.2.5/postgres.ts";
 ```
 
 ## Usage
@@ -34,7 +34,7 @@ To use the command line interface, you must create a script that will initialize
 the Migrate instance and call the run command from [cli.ts](cli.ts). An example
 can be found [here](#postgres-cli).
 
-See [deno docs](https://doc.deno.land/https/deno.land/x/migrate@0.2.4/cli.ts)
+See [deno docs](https://doc.deno.land/https/deno.land/x/migrate@0.2.5/cli.ts)
 for more information.
 
 #### Command: init
@@ -160,7 +160,7 @@ different ways to use the migrate module. Only one is required to use the
 migrate tool.
 
 See
-[deno docs](https://doc.deno.land/https/deno.land/x/migrate@0.2.4/postgres.ts)
+[deno docs](https://doc.deno.land/https/deno.land/x/migrate@0.2.5/postgres.ts)
 for more information.
 
 #### Postgres script

--- a/deps.ts
+++ b/deps.ts
@@ -1,8 +1,8 @@
-export { parse } from "https://deno.land/std@0.150.0/flags/mod.ts";
-export type { Args } from "https://deno.land/std@0.150.0/flags/mod.ts";
+export { parse } from "https://deno.land/std@0.163.0/flags/mod.ts";
+export type { Args } from "https://deno.land/std@0.163.0/flags/mod.ts";
 
-export { walk } from "https://deno.land/std@0.150.0/fs/walk.ts";
-export type { WalkEntry } from "https://deno.land/std@0.150.0/fs/walk.ts";
+export { walk } from "https://deno.land/std@0.163.0/fs/walk.ts";
+export type { WalkEntry } from "https://deno.land/std@0.163.0/fs/walk.ts";
 
 export {
   dirname,
@@ -11,9 +11,9 @@ export {
   relative,
   resolve,
   toFileUrl,
-} from "https://deno.land/std@0.150.0/path/mod.ts";
+} from "https://deno.land/std@0.163.0/path/mod.ts";
 
-export { readLines } from "https://deno.land/std@0.150.0/io/buffer.ts";
-export { StringReader } from "https://deno.land/std@0.150.0/io/readers.ts";
+export { readLines } from "https://deno.land/std@0.163.0/io/buffer.ts";
+export { StringReader } from "https://deno.land/std@0.163.0/io/readers.ts";
 
-export { delay } from "https://deno.land/std@0.150.0/async/delay.ts";
+export { delay } from "https://deno.land/std@0.163.0/async/delay.ts";

--- a/postgres_deps.ts
+++ b/postgres_deps.ts
@@ -2,5 +2,5 @@ export {
   Client,
   Transaction,
   TransactionError,
-} from "https://deno.land/x/postgres@v0.16.1/mod.ts";
-export type { ClientOptions } from "https://deno.land/x/postgres@v0.16.1/mod.ts";
+} from "https://deno.land/x/postgres@v0.17.0/mod.ts";
+export type { ClientOptions } from "https://deno.land/x/postgres@v0.17.0/mod.ts";

--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -1,4 +1,4 @@
-FROM denoland/deno:1.24.1
+FROM denoland/deno:1.27.2
 WORKDIR /app
 
 # Install wait utility

--- a/test_deps.ts
+++ b/test_deps.ts
@@ -5,17 +5,17 @@ export {
   assertRejects,
   assertStrictEquals,
   assertThrows,
-} from "https://deno.land/std@0.150.0/testing/asserts.ts";
+} from "https://deno.land/std@0.163.0/testing/asserts.ts";
 
-export { ensureDir } from "https://deno.land/std@0.150.0/fs/ensure_dir.ts";
+export { ensureDir } from "https://deno.land/std@0.163.0/fs/ensure_dir.ts";
 
-export { describe, it } from "https://deno.land/std@0.150.0/testing/bdd.ts";
+export { describe, it } from "https://deno.land/std@0.163.0/testing/bdd.ts";
 
 export {
   assertSpyCall,
   assertSpyCalls,
   spy,
   stub,
-} from "https://deno.land/std@0.150.0/testing/mock.ts";
+} from "https://deno.land/std@0.163.0/testing/mock.ts";
 
-export { FakeTime } from "https://deno.land/std@0.150.0/testing/time.ts";
+export { FakeTime } from "https://deno.land/std@0.163.0/testing/time.ts";


### PR DESCRIPTION
This module breaks in Deno 1.27.0+ because of a breaking change that affected the postgres dependency. This updates migrate to use the latest version of std and postgres.