### PR TITLE
Add a --help command, more verbose console logs, make dir if not present, and load before apply automatically.

### DIFF
--- a/basic.ts
+++ b/basic.ts
@@ -1,27 +1,27 @@
 import { applyMigrations, init, loadMigrations } from "./cli.ts";
+import { logger } from "./lib.ts";
 import { Migrate } from "./migrate.ts";
 
 export async function apply(migrate: Migrate): Promise<void> {
-  console.log("Connecting to database");
+  logger("info", "Connecting to database");
   try {
     await migrate.connect();
   } catch (error) {
-    console.log("Failed to connect to database");
+    logger("error", "Failed to connect to database");
     throw error;
   }
 
-  console.log("Acquiring migrate lock");
+  logger("apply", "Acquiring migrate lock");
   const lock = await migrate.lock();
-  console.log("Acquired migrate lock");
+  logger("apply", "Acquired migrate lock");
 
   await init(migrate);
   const migrations = await loadMigrations(migrate);
   await applyMigrations(migrate, migrations);
 
-  console.log("Releasing migrate lock");
+  logger("apply", "Releasing migrate lock");
   await lock.release();
-  console.log("Released migrate lock");
+  logger("apply", "Released migrate lock");
 
-  console.log("Done");
   await migrate.end();
 }

--- a/basic_test.ts
+++ b/basic_test.ts
@@ -38,9 +38,7 @@ it(
   async function () {
     const { migrate } = this;
     const process = Deno.run({
-      cmd: [
-        resolve(migrate.migrationsDir, "../migrate_basic.ts"),
-      ],
+      cmd: [resolve(migrate.migrationsDir, "../migrate_basic.ts")],
       stdout: "piped",
     });
     try {
@@ -49,20 +47,19 @@ it(
       assertEquals(
         decoder.decode(output),
         `\
-Connecting to database
-Acquiring migrate lock
-Acquired migrate lock
-Creating migration table if it does not exist
-Created migration table
-Loading migrations
-2 new migrations found
-2 unapplied migrations
-Applying migration: 0_user_create.sql
-Applying migration: 1_user_add_column_email.sql
-Finished applying all migrations
-Releasing migrate lock
-Released migrate lock
-Done
+[INFO]: Connecting to database
+[APPLY]: Acquiring migrate lock
+[APPLY]: Acquired migrate lock
+[INIT]: Initializing migrate...
+[INIT]: Database has been initialised with migrations table and migration timestamp trigger.
+[INIT]: To get started, create your first migration using the filename format of 0_migration_title.{sql,json} and run \`apply\`
+[LOAD]: 2 new migrations found
+[APPLY]: 2 unapplied migrations
+[APPLY]: Applying migration: 0_user_create.sql
+[APPLY]: Applying migration: 1_user_add_column_email.sql
+[APPLY]: Finished applying all migrations
+[APPLY]: Releasing migrate lock
+[APPLY]: Released migrate lock
 `,
       );
     } finally {
@@ -82,9 +79,7 @@ it(applyTests, "applies unapplied migrations", async function () {
   await delay(1);
 
   const process = Deno.run({
-    cmd: [
-      resolve(migrate.migrationsDir, "../migrate_basic.ts"),
-    ],
+    cmd: [resolve(migrate.migrationsDir, "../migrate_basic.ts")],
     stdout: "piped",
   });
   try {
@@ -93,21 +88,19 @@ it(applyTests, "applies unapplied migrations", async function () {
     assertEquals(
       decoder.decode(output),
       `\
-Connecting to database
-Acquiring migrate lock
-Acquired migrate lock
-Creating migration table if it does not exist
-Migration table already exists
-Loading migrations
-No new migrations found
-No migrations updated
-No migrations deleted
-1 unapplied migration
-Applying migration: 1_user_add_column_email.sql
-Finished applying all migrations
-Releasing migrate lock
-Released migrate lock
-Done
+[INFO]: Connecting to database
+[APPLY]: Acquiring migrate lock
+[APPLY]: Acquired migrate lock
+[INIT]: Initializing migrate...
+[ERROR]: Migration table already exists. Have you already initialized migrate?
+[LOAD]: No new migrations found
+[LOAD]: No migrations updated
+[LOAD]: No migrations deleted
+[APPLY]: 1 unapplied migration
+[APPLY]: Applying migration: 1_user_add_column_email.sql
+[APPLY]: Finished applying all migrations
+[APPLY]: Releasing migrate lock
+[APPLY]: Released migrate lock
 `,
     );
   } finally {
@@ -128,9 +121,7 @@ it(applyTests, "no unapplied migrations", async function () {
   await delay(1);
 
   const process = Deno.run({
-    cmd: [
-      resolve(migrate.migrationsDir, "../migrate_basic.ts"),
-    ],
+    cmd: [resolve(migrate.migrationsDir, "../migrate_basic.ts")],
     stdout: "piped",
   });
   try {
@@ -139,19 +130,17 @@ it(applyTests, "no unapplied migrations", async function () {
     assertEquals(
       decoder.decode(output),
       `\
-Connecting to database
-Acquiring migrate lock
-Acquired migrate lock
-Creating migration table if it does not exist
-Migration table already exists
-Loading migrations
-No new migrations found
-No migrations updated
-No migrations deleted
-No unapplied migrations
-Releasing migrate lock
-Released migrate lock
-Done
+[INFO]: Connecting to database
+[APPLY]: Acquiring migrate lock
+[APPLY]: Acquired migrate lock
+[INIT]: Initializing migrate...
+[ERROR]: Migration table already exists. Have you already initialized migrate?
+[LOAD]: No new migrations found
+[LOAD]: No migrations updated
+[LOAD]: No migrations deleted
+[APPLY]: No unapplied migrations
+[APPLY]: Releasing migrate lock
+[APPLY]: Released migrate lock
 `,
     );
   } finally {

--- a/deps.ts
+++ b/deps.ts
@@ -17,3 +17,4 @@ export { readLines } from "https://deno.land/std@0.163.0/io/buffer.ts";
 export { StringReader } from "https://deno.land/std@0.163.0/io/readers.ts";
 
 export { delay } from "https://deno.land/std@0.163.0/async/delay.ts";
+export { existsSync } from "https://deno.land/std@0.220.1/fs/mod.ts";

--- a/lib.ts
+++ b/lib.ts
@@ -1,0 +1,29 @@
+import { Migrate } from "./postgres.ts";
+
+type CLI_FUNCTION = keyof typeof colors;
+
+const colors: Record<string, string> = {
+  apply: "purple",
+  init: "green",
+  error: "red",
+  info: "blue",
+  list: "orange",
+  load: "pink",
+};
+
+export const logger = (cliFunction: CLI_FUNCTION, ...message: string[]) => {
+  console.log(
+    `%c[${cliFunction.toUpperCase()}]:`,
+    `color: ${colors[cliFunction]};`,
+    ...message,
+  );
+};
+
+export const createMigrationDirectoryIfNotExists = (migrate: Migrate) => {
+  try {
+    Deno.mkdirSync(migrate.migrationsDir);
+    logger("init", "The migrations directory has been created.");
+  } catch (_err) {
+    return;
+  }
+};

--- a/migrate.ts
+++ b/migrate.ts
@@ -46,9 +46,9 @@ export interface MigrationJSON {
 
 /** A script for generating migration queries. */
 export interface MigrationScript<GenerateOptions = unknown> {
-  generateQueries(options?: GenerateOptions):
-    | Iterable<MigrationQuery>
-    | AsyncIterable<MigrationQuery>;
+  generateQueries(
+    options?: GenerateOptions,
+  ): Iterable<MigrationQuery> | AsyncIterable<MigrationQuery>;
   disableTransaction?: boolean;
 }
 
@@ -157,9 +157,10 @@ export abstract class Migrate<GenerateOptions = unknown> {
       ({ queries } = migration);
       useTransaction = !migration.disableTransaction;
     } else {
-      const { generateQueries, disableTransaction }: MigrationScript<
-        GenerateOptions
-      > = await import(toFileUrl(path).href);
+      const {
+        generateQueries,
+        disableTransaction,
+      }: MigrationScript<GenerateOptions> = await import(toFileUrl(path).href);
       if (!generateQueries) {
         throw new Error(
           "migration script must export generateQueries function",
@@ -170,4 +171,10 @@ export abstract class Migrate<GenerateOptions = unknown> {
     }
     return { queries, useTransaction };
   }
+}
+
+function createMigrationDirectoryIfNotExists(
+  migrationsDir: string | undefined,
+) {
+  throw new Error("Function not implemented.");
 }


### PR DESCRIPTION
Hopefully this resolves #8 a little bit. I'm opening this as a starting point for some ideas for which I think would make it easier for someone to pick this up quicker.

### More verbose console logs.

This introduces some more verbose console logs, with some instructions to help people pick up what to do next. It also adds a `--help` flag which can be used on the root, which explains a little more how to use this tool.

For example, now when `init` is used it gives you some steps on how to proceed.

### Make directory if it doesn't exist

Just a nice to have where if you specify a directory for the `migrationsDir` and it doesn't exist, it generates it.

### Combining apply and load

This introduces the load function into apply, so that rather than having it as two steps it just does it all at once. 



